### PR TITLE
Crash fix, visual edition history on exact match, text description if no image

### DIFF
--- a/handlers/magic/cardHandler.js
+++ b/handlers/magic/cardHandler.js
@@ -18,7 +18,15 @@ CardHandler.prototype.handle = function * (request) {
     var source = {
         cardImageLink: card.imgUrl,
         cardStoreLink: card.storeUrl,
-        additionalSearchMatches: card.additionalSearchMatches
+        cardName: card.name,
+        cardText: card.text,
+        cardType: card.type,
+        cardColor: card.color,
+        cardHasImage: card.hasImage,
+        additionalSearchMatches: card.additionalSearchMatches,
+        editions: card.editions,
+        additionalMatchNumber: card.additionalMatchNumber,
+        exactMatch: card.exactMatch
     };
     return this.pageBuilder(source);
 };

--- a/models/magic/cardModel.js
+++ b/models/magic/cardModel.js
@@ -1,4 +1,4 @@
-function CardModel(name, type, color, text, rarity, set, avgPrice, imgUrl, storeUrl, additionalSearchMatches) {
+function CardModel(name, type, color, text, rarity, set, avgPrice, imgUrl, storeUrl, hasImage, additionalSearchMatches, editions, additionalMatchNumber, exactMatch) {
     this.name = name;
     this.type = type;
     this.color = color;
@@ -8,7 +8,11 @@ function CardModel(name, type, color, text, rarity, set, avgPrice, imgUrl, store
     this.avgPrice = avgPrice;
     this.imgUrl = imgUrl;
     this.storeUrl = storeUrl;
+    this.hasImage = hasImage;
     this.additionalSearchMatches = additionalSearchMatches;
+    this.editions = editions;
+    this.additionalMatchNumber = additionalMatchNumber
+    this.exactMatch = exactMatch;
 }
 
 module.exports = CardModel;

--- a/services/cardService.js
+++ b/services/cardService.js
@@ -24,7 +24,7 @@ CardService.prototype.getCardByNameAsync = function(cardName) {
 
             // try to find exact match
             var card = _und.find(cards, function(icard) {
-                return icard.name.toLowerCase() == cardName.toLowerCase();
+                return icard.name.trim().toLowerCase() == cardName.trim().toLowerCase();
             });
 
 
@@ -32,24 +32,36 @@ CardService.prototype.getCardByNameAsync = function(cardName) {
                 card = cards[0];
             }
 
-            var additionalSearchMatches = _und.without(cards, card)
-
+            var additionalSearchMatches = _und.chain(cards).without(card).first(50).value();
+            var additionalMatchNumber = (cards.length - 51);
+            additionalMatchNumber = additionalMatchNumber > 0 ? additionalMatchNumber : undefined;
+            var exactMatch = additionalSearchMatches.length == 0;
         	log.debug(card);
 
             var cardEditions = _und.sortBy(card.editions, function(edition) {
                 return -edition.multiverse_id;
             });
-        	var setData = cardEditions[0];
+
+        	var setData = cardEditions.shift();
+            var hasImage = setData.multiverse_id != 0;
+
+            var additionalEditions = _und.each(cardEditions, function(edition) {
+                edition.hasImage = edition.multiverse_id != 0;
+            });
             return new CardModel(card.name,
-                card.type,
-                card.color,
+                card.types,
+                card.colors,
                 card.text,
                 setData['rarity'],
                 setData['set'],
                 setData['price']['average'],
                 setData['image_url'],
                 setData['store_url'],
-                additionalSearchMatches);
+                hasImage,
+                additionalSearchMatches, 
+                additionalEditions,
+                additionalMatchNumber,
+                exactMatch);
         });
 };
 

--- a/templates/magic/card.hbs
+++ b/templates/magic/card.hbs
@@ -1,19 +1,39 @@
 <table>
     <tr>
         <td>
-            <a href="{{cardStoreLink}}"><img src="{{cardImageLink}}" height="300px"/></a>
+            {{#if cardHasImage}}
+                <a href="{{cardStoreLink}}"><img src="{{cardImageLink}}" height="300px"/></a>
+            {{else}}
+                <p><b>Name:</b> <a href="{{cardStoreLink}}">{{cardName}}</a>
+                <p><b>Type:</b> {{cardType}}
+                <p><b>Color:</b> {{cardColor}}
+                <p><b>Text:</b> {{cardText}}
+            {{/if}}
         </td>
-        {{#if additionalSearchMatches}}
         <td valign="top">
-            <p>Additional Search Matches:
-            <ul>
-            {{#each additionalSearchMatches}}
+            {{#if additionalSearchMatches}}
+                <p>Additional Search Matches:
+                <ul>
+                {{#each additionalSearchMatches}}
                 <li>
                     <a href="{{store_url}}">{{name}}</a>
                 </li>
-            {{/each}}
-        </ul>
+                {{/each}}
+                {{#if additionalMatchNumber}}
+                <li>{{additionalMatchNumber}} more...</li>
+                {{/if}}
+                </ul>
+            {{/if}}
+            {{#if exactMatch}}
+                {{#each editions}}
+                    <!--{{set}}-->
+                    {{#if hasImage}}
+                    <span><a href="{{store_url}}"><img src="{{image_url}}" height="200px"/></a></span>
+                    {{else}}
+                    <!-- <span>NO IMAGE</span> -->
+                    {{/if}}
+                {{/each}}
+            {{/if}}
         </td>
-        {{/if}}
     </tr>
 </table>


### PR DESCRIPTION
- Fixed crash when querying for "/magic card light" or "/magic card dragon" (it was because of an overflow in the hip chat bot's HTML input)
- Added in visual history of editions if they have images and if the card is an exact match (with no other search results)
- Added in description of card in the event that a card doesn't have an image.
  Resolves issues #7 and #10 
